### PR TITLE
fix #16:  修复 Native Canvas 事件监听接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ Page({
   },
   touchStart(e) {
     if (this.canvas) {
-      this.canvas.emitEvent('touchstart', [e]);
+      this.canvas.ctx.emitter.emit('touchStart', [e]);
     }
   },
   touchMove(e) {
     if (this.canvas) {
-      this.canvas.emitEvent('touchmove', [e]);
+      this.canvas.ctx.emitter.emit('touchMove', [e]);
     }
   },
   touchEnd(e) {
     if (this.canvas) {
-      this.canvas.emitEvent('touchend', [e]);
+      this.canvas.ctx.emitter.emit('touchEnd', [e]);
     }
   }
 });

--- a/src/core.js
+++ b/src/core.js
@@ -12,16 +12,17 @@ const EVENTS_MAP = {
 Core.Util.addEventListener = function(source, type, listener) {
   const context = source.getContext('2d');
   type = EVENTS_MAP[type]; // 支付宝小程序事件名为驼峰结构
-  context.addEventListener(type, listener);
+  context.emitter.addListener(type, listener);
 };
 
 Core.Util.removeEventListener = function(source, type, listener) {
   const context = source.getContext('2d');
   type = EVENTS_MAP[type]; // 支付宝小程序事件名为驼峰结构
-  context.removeEventListener(type, listener);
+  context.emitter.removeListener(type, listener);
 };
 
 Core.Util.createEvent = function(event, chart) {
+  event = event[0]
   const type = event.type;
   let x = 0;
   let y = 0;

--- a/src/core.js
+++ b/src/core.js
@@ -22,7 +22,9 @@ Core.Util.removeEventListener = function(source, type, listener) {
 };
 
 Core.Util.createEvent = function(event, chart) {
-  event = event[0]
+  if(event[0]){
+    event = event[0]
+  }  
   const type = event.type;
   let x = 0;
   let y = 0;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
具体问题详见：#16 
调试发现 native canvas 将事件处理函数移至了 `context.emitter` 下。根据原生 `canvas` 事件监听接口的变化，本次 PR 作出了如下修改：
1. 更改了添加和移除监听器的函数
2. 由于实例触发事件时，以`[e]`的形式传入事件参数， `Core.Util.createEvent` 接收到的事件仍是数组（与微信不同），因此对传入的事件参数进行了优化处理，支持在 `this.canvas.ctx.emitter.emit` 中直接传入 `e`, 或者仍可以沿用 `[e]`
3. 更新了 `readme` 中实例触发事件的方法
